### PR TITLE
Fix pattern for python minimal version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/Mickael-Roger/chaostoolkit-ansible/compare/0.2.0...HEAD
 
+### Changed
+
+- Fixed python minimal dependency pattern as per https://github.com/pypa/packaging/issues/673
+
 ### Added
 
 - MANIFEST.in for a complete source distribution for integrating with the

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup_params = dict(
     install_requires=install_require,
     tests_require=test_require,
     setup_requires=pytest_runner,
-    python_requires=">=3.5.*",
+    python_requires=">=3.5",
 )
 
 


### PR DESCRIPTION
Hello Mickael,

As per https://github.com/pypa/packaging/issues/673

Otherwise, I cannot build this extension into the main chaostoolkit website/documentation.

Notice, I've left a miniaml version of Python 3.5 though the chaostoolkit itself will work only with 3.7. WXe follow Python EOL timeline. But that shouldn't be an issue with a release that keeps 3.5 here.

cc @Mickael-Roger 